### PR TITLE
ntdvps socials

### DIFF
--- a/bsky_users.yaml
+++ b/bsky_users.yaml
@@ -32,7 +32,10 @@ starterpacks:
     - nkallergis.bsky.social
     - rickdonato.bsky.social
     - hey-laura.bsky.social
+
+    # name: Roman Dodin; X/Twitter: https://x.com/ntdvps; linkedin: https://www.linkedin.com/in/rdodin/
     - netdevops.me
+
     - hans.thienpondt.be
     - marcom4rtinez.bsky.social
     - ryanmerolle.bsky.social


### PR DESCRIPTION
I was thinking it would be beneficial to provide context to the list of users (users should consent to this, or edit the list to add it directly)

This gives more insight into who people are/were, since bsky handles are often different from twitters